### PR TITLE
Add option to determine ipv4 or ipv6 address explicitly

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDefaultConsensus(t *testing.T) {
-	consensus := DefaultConsensus(nil)
+	consensus := DefaultConsensus(nil, nil)
 	if consensus == nil {
 		t.Fatal("default consensus should never be nil")
 	}

--- a/error.go
+++ b/error.go
@@ -19,4 +19,6 @@ var (
 	// ErrNoSource is returned when a voter is added,
 	// which doesn't have a source specified
 	ErrNoSource = errors.New("no voter's source given")
+	// ErrInvalidProtocol is used when setting an invalid ip protocol on the conensus
+	ErrInvalidProtocol = errors.New("invalid ip protocol specified")
 )

--- a/sources.go
+++ b/sources.go
@@ -48,7 +48,13 @@ func (s *HTTPSource) IP(timeout time.Duration, logger *log.Logger) (net.IP, erro
 	}
 	req.Header.Set("User-Agent", "go-external-ip (github.com/glendc/go-external-ip)")
 
-	client := &http.Client{Timeout: timeout}
+	// transport to avoid goroutine leak
+	tr := &http.Transport{
+	MaxIdleConns:       1,
+	IdleConnTimeout:    3 * time.Second,
+	DisableKeepAlives:  true,
+	}
+	client := &http.Client{Timeout: timeout, Transport: tr}
 	// Do the request and read the body for non-error results.
 	resp, err := client.Do(req)
 	if err != nil {

--- a/sources.go
+++ b/sources.go
@@ -1,11 +1,13 @@
 package externalip
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -38,7 +40,7 @@ func (s *HTTPSource) WithParser(parser ContentParser) *HTTPSource {
 }
 
 // IP implements Source.IP
-func (s *HTTPSource) IP(timeout time.Duration, logger *log.Logger) (net.IP, error) {
+func (s *HTTPSource) IP(timeout time.Duration, logger *log.Logger, protocol uint) (net.IP, error) {
 	// Define the GET method with the correct url,
 	// setting the User-Agent to our library
 	req, err := http.NewRequest("GET", s.url, nil)
@@ -50,10 +52,24 @@ func (s *HTTPSource) IP(timeout time.Duration, logger *log.Logger) (net.IP, erro
 
 	// transport to avoid goroutine leak
 	tr := &http.Transport{
-	MaxIdleConns:       1,
-	IdleConnTimeout:    3 * time.Second,
-	DisableKeepAlives:  true,
+		MaxIdleConns:      1,
+		IdleConnTimeout:   3 * time.Second,
+		DisableKeepAlives: true,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: false,
+			Control: func(network, address string, c syscall.RawConn) error {
+				if protocol == 4 && network == "tcp6" {
+					return errors.New("rejecting ipv6 connection")
+				} else if protocol == 6 && network == "tcp4" {
+					return errors.New("rejecting ipv4 connection")
+				}
+				return nil
+			},
+		}).DialContext,
 	}
+
 	client := &http.Client{Timeout: timeout, Transport: tr}
 	// Do the request and read the body for non-error results.
 	resp, err := client.Do(req)

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ type Source interface {
 	// net.IP should never be <nil> when error is <nil>
 	// It is recommended that the IP function times out,
 	// if no result could be found, after the given timeout duration.
-	IP(timeout time.Duration, logger *log.Logger) (net.IP, error)
+	IP(timeout time.Duration, logger *log.Logger, protocol uint) (net.IP, error)
 }
 
 // voter adds weight to the IP given by a source.


### PR DESCRIPTION
Fixes #2 - By rejecting connections using the TCP method we don't want for the IP protocol, the HTTP client will move on to the next connection. This eventually gets you the connection you're after. The sources will see the request from this package as either a ipv4 or ipv6 connection and return the corresponding IP protocol address.

Example usage:
```
consensus := externalip.DefaultConsensus(nil, nil)
connsensus.UseIPProtocol(4)
// or
connsensus.UseIPProtocol(6)
ip, err := consensus.ExternalIP()
```

Tested on a server that has both ipv4 and ipv6 addresses on the interface. The default will return me an ipv6 address however specifying an IP protocol explicitly will return what I wanted.

Also includes [Tejas patch](https://github.com/GlenDC/go-external-ip/commit/8baefb90b9da4ab744b730f7b172a5825c3cc871) since I needed to add a transport anyway and this helps resolve a leak too.