### PR TITLE
Remove tnx.nl source

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -32,7 +32,6 @@ func DefaultConsensus(cfg *ConsensusConfig, logger *log.Logger) *Consensus {
 	consensus.AddVoter(NewHTTPSource("http://checkip.amazonaws.com/"), 1)
 	consensus.AddVoter(NewHTTPSource("http://ident.me/"), 1)
 	consensus.AddVoter(NewHTTPSource("http://whatismyip.akamai.com/"), 1)
-	consensus.AddVoter(NewHTTPSource("http://tnx.nl/ip"), 1)
 	consensus.AddVoter(NewHTTPSource("http://myip.dnsomatic.com/"), 1)
 	consensus.AddVoter(NewHTTPSource("http://diagnostic.opendns.com/myip"), 1)
 


### PR DESCRIPTION
Hi,

As the administrator of tnx.nl, I'm honored but also slightly annoyed that you chose my URL as one of the sources. Your `go-external-ip` is now causing approximately 35 requests per second on average. All other user agents combined do only 5 requests per second.

I understand that it might take a while for your users to upgrade their instances of `go-external-ip`, so I'll probably keep the URL working for now, albeit without the https redirect to save some CPU usage.

Thank you for choosing my server. Thank you for removing it from the list.

Best regards,

Juerd Waalboer
TNX