### PR TITLE
Add option to determine ipv4 or ipv6 address explicitly

### DIFF
--- a/cmd/exip/main.go
+++ b/cmd/exip/main.go
@@ -7,13 +7,14 @@ import (
 	"os"
 	"time"
 
-	"github.com/glendc/go-external-ip"
+	externalip "github.com/glendc/go-external-ip"
 )
 
 // CLI Flags
 var (
-	timeout = flag.Duration("t", time.Second*5, "consensus's voting timeout")
-	verbose = flag.Bool("v", false, "log errors to STDERR, when defined")
+	timeout  = flag.Duration("t", time.Second*5, "consensus's voting timeout")
+	verbose  = flag.Bool("v", false, "log errors to STDERR, when defined")
+	protocol = flag.Uint("p", 0, "IP Protocol to be used (0, 4, or 6)")
 )
 
 func main() {
@@ -32,18 +33,22 @@ func main() {
 
 	// create the consensus
 	consensus := externalip.DefaultConsensus(cfg, logger)
+	err := consensus.UseIPProtocol(*protocol)
+	errCheck(err)
 
 	// retrieve the external ip
 	ip, err := consensus.ExternalIP()
+	errCheck(err)
 
-	// simple error handling
+	// success, simply output the IP in string format
+	fmt.Println(ip.String())
+}
+
+func errCheck(err error) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-
-	// success, simply output the IP in string format
-	fmt.Println(ip.String())
 }
 
 func init() {

--- a/consensus.go
+++ b/consensus.go
@@ -70,9 +70,10 @@ func (cfg *ConsensusConfig) WithTimeout(timeout time.Duration) *ConsensusConfig 
 // Its `ExternalIP` method allows you to ask for your ExternalIP,
 // influenced by all its added voters.
 type Consensus struct {
-	voters  []voter
-	timeout time.Duration
-	logger  *log.Logger
+	voters   []voter
+	timeout  time.Duration
+	logger   *log.Logger
+	protocol uint
 }
 
 // AddVoter adds a voter to this consensus.
@@ -108,7 +109,7 @@ func (c *Consensus) ExternalIP() (net.IP, error) {
 		wg.Add(1)
 		go func(v voter) {
 			defer wg.Done()
-			ip, err := v.source.IP(c.timeout, c.logger)
+			ip, err := v.source.IP(c.timeout, c.logger, c.protocol)
 			if err == nil && ip != nil {
 				vlock.Lock()
 				defer vlock.Unlock()
@@ -144,4 +145,17 @@ func (c *Consensus) ExternalIP() (net.IP, error) {
 	// as the found IP was parsed previously,
 	// we know it cannot be nil and is valid
 	return net.ParseIP(externalIP), nil
+}
+
+// UseIPProtocol will set the IP Protocol to use for http requests
+// to the sources. If zero, it will not discriminate. This is useful
+// when you want to get the external IP in a specific protocol.
+// Protocol only supports 0, 4 or 6.
+func (c *Consensus) UseIPProtocol(protocol uint) error {
+	if protocol != 0 && protocol != 4 && protocol != 6 {
+		c.logger.Println("[ERROR] only ipv4 and ipv6 protocol is supported")
+		return ErrInvalidProtocol
+	}
+	c.protocol = protocol
+	return nil
 }

--- a/error.go
+++ b/error.go
@@ -19,4 +19,6 @@ var (
 	// ErrNoSource is returned when a voter is added,
 	// which doesn't have a source specified
 	ErrNoSource = errors.New("no voter's source given")
+	// ErrInvalidProtocol is used when setting an invalid ip protocol on the conensus
+	ErrInvalidProtocol = errors.New("invalid ip protocol specified")
 )

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ type Source interface {
 	// net.IP should never be <nil> when error is <nil>
 	// It is recommended that the IP function times out,
 	// if no result could be found, after the given timeout duration.
-	IP(timeout time.Duration, logger *log.Logger) (net.IP, error)
+	IP(timeout time.Duration, logger *log.Logger, protocol uint) (net.IP, error)
 }
 
 // voter adds weight to the IP given by a source.


### PR DESCRIPTION
_New version of MR #3_

Fixes #2 - By rejecting connections using the TCP method we don't want for the IP protocol, the HTTP client will move on to the next connection. This eventually gets you the connection you're after. The sources will see the request from this package as either a ipv4 or ipv6 connection and return the corresponding IP protocol address.

Example usage:
```
consensus := externalip.DefaultConsensus(nil, nil)
connsensus.UseIPProtocol(4)
// or
connsensus.UseIPProtocol(6)
ip, err := consensus.ExternalIP()
```

Tested on a server that has both ipv4 and ipv6 addresses on the interface. The default will return me an ipv6 address however specifying an IP protocol explicitly will return what I wanted.

Also includes [Tejas patch](https://github.com/GlenDC/go-external-ip/commit/8baefb90b9da4ab744b730f7b172a5825c3cc871) since I needed to add a transport anyway and this helps resolve a leak too.