### PR TITLE
Remove OpenDNS URL

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -33,7 +33,6 @@ func DefaultConsensus(cfg *ConsensusConfig, logger *log.Logger) *Consensus {
 	consensus.AddVoter(NewHTTPSource("http://ident.me/"), 1)
 	consensus.AddVoter(NewHTTPSource("http://whatismyip.akamai.com/"), 1)
 	consensus.AddVoter(NewHTTPSource("http://myip.dnsomatic.com/"), 1)
-	consensus.AddVoter(NewHTTPSource("http://diagnostic.opendns.com/myip"), 1)
 
 	return consensus
 }


### PR DESCRIPTION
This URL is no longer working. OpenDNS recommends using http://myip.dnsomatic.com/, which is already part of the list of queried URLs.

Because this URL is not working, we've seen connection timeouts on a few networks. On some networks, connecting to http://diagnostic.opendns.com/myip results in an immediate TCP reset and no delay. But on the affected networks, the connection does time out (confirmed on OVH and a residential network, at least). One application uses go-external-ip to know its IP every time it runs. On the networks where the server is not sending the reset, it causes a 5-second delay every time the application is run.